### PR TITLE
Make Scanner a newtype

### DIFF
--- a/lib/Scanner/Internal.hs
+++ b/lib/Scanner/Internal.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString as ByteString
 import Control.Monad
 
 -- | CPS scanner without backtracking
-data Scanner a = Scanner
+newtype Scanner a = Scanner
   { run :: forall r. ByteString -> Next a r -> Result r
   }
 


### PR DESCRIPTION
Performance is the same for most of the Redis examples, but much faster for
multibulk. GHC perhaps optimizes it better when used in non-inlined functions.
- Before:

benchmarking multi/Scanner
time                 556.1 ns   (538.6 ns .. 582.3 ns)
                     0.989 RÂ²   (0.982 RÂ² .. 0.995 RÂ²)
mean                 560.5 ns   (544.6 ns .. 577.8 ns)
std dev              57.16 ns   (44.10 ns .. 73.20 ns)
variance introduced by outliers: 90% (severely inflated)
- After:

benchmarking multi/Scanner
time                 374.0 ns   (370.4 ns .. 377.8 ns)
                     0.999 RÂ²   (0.998 RÂ² .. 0.999 RÂ²)
mean                 375.7 ns   (370.9 ns .. 380.6 ns)
std dev              16.45 ns   (13.53 ns .. 20.47 ns)
variance introduced by outliers: 62% (severely inflated)
